### PR TITLE
Style fixes

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,8 +9,10 @@ export default class App extends Component {
 	render() {
 		return (
 			<div>
-				<AddCustomEvent />
-				<Paginator />
+				<div className="topbar">
+					<Paginator />
+					<AddCustomEvent />
+				</div>
 				<VisibleEventTimeline />
 				<VisibleEventStream />
 			</div>

--- a/src/actions.js
+++ b/src/actions.js
@@ -21,7 +21,7 @@ export function listenToFirebase() {
 			.child(DATA_FIELD)
 			.orderByChild("timestamp")
 			.startAt(paginator.startDate)
-			.endAt(paginator.startDate + 3600 * 14)
+			.endAt(paginator.startDate + 3600 * 15)
 			.on('value', (snapshot) => {
 				dispatch({type: REPLACE_EVENTS, events: snapshot.val() || {}});
 			})

--- a/src/components/AddEvent.js
+++ b/src/components/AddEvent.js
@@ -3,7 +3,7 @@ import React, { Component, PropTypes } from 'react'
 export default class AddEvent extends Component {
 	render() {
 		return (
-			<div>
+			<div className="addevent">
 				<input type="text" ref="text" />
 				<select ref="severity">
 						<option value="info">info</option>

--- a/src/components/EventTimeline.js
+++ b/src/components/EventTimeline.js
@@ -35,7 +35,6 @@ export default class EventStream extends Component {
 								.map((eventID, eventindex) =>
 									<TimelineItem {...this.props.events.list[eventID]}
 											key={eventindex}
-											widthPercentage={100 / row.eventIDs.length}
 											onClick={() => this.props.onEventClick(eventID)} />
 									)
 							}

--- a/src/components/TimelineItem.js
+++ b/src/components/TimelineItem.js
@@ -8,9 +8,17 @@ export default class TimelineItem extends Component {
 		const eventClass = `event__label event__severity-${this.props.severity} ${this.props.completed ? ' event-completed' : ''}`
 
 		return (
-			<div className="event" style={{width: this.props.widthPercentage + '%'}} onClick={this.props.onClick}>
+			<div className="event" onClick={this.props.onClick}>
 				<div className={eventClass}>
-					{formatTime(this.props.timestamp)}: {this.props.text}
+					<header>
+						<time>{formatTime(this.props.timestamp)}</time>
+						{(this.props.meta && this.props.meta.user_name) ?
+							<span>by @{this.props.meta.user_name}</span>
+							:
+							null
+						}
+					</header>
+					{this.props.text}
 				</div>
 			</div>
 		)
@@ -19,7 +27,6 @@ export default class TimelineItem extends Component {
 
 TimelineItem.propTypes = {
 	onClick: PropTypes.func.isRequired,
-	widthPercentage: PropTypes.number.isRequired,
 	timestamp: PropTypes.number.isRequired,
 	text: PropTypes.string.isRequired
 }

--- a/src/containers/VisibleEventTimeline.js
+++ b/src/containers/VisibleEventTimeline.js
@@ -5,7 +5,8 @@ import EventTimeline from '../components/EventTimeline'
 
 const getVisibleEvents = (events) => {
 	let newevents = Object.keys(events.list).reduce((acc, k) => {
-		if (events.list[k].type !== 'slack' || events.list[k].text.indexOf('~~changelog~~') !== -1) {
+		if (events.list[k].type !== 'slack' || events.list[k].text.indexOf('/changelog') !== -1) {
+			events.list[k].text = events.list[k].text.replace('/changelog', '');
 			acc[k] = events.list[k]
 		}
 		return acc
@@ -17,7 +18,7 @@ const mapStateToProps = (state) => {
 	return {
 		events: getVisibleEvents(state.events),
 		startTime: state.paginator.startDate,
-		endTime: state.paginator.startDate + 3600 * 14
+		endTime: state.paginator.startDate + 3600 * 15
 	}
 }
 

--- a/styles/app.css
+++ b/styles/app.css
@@ -1,9 +1,28 @@
 body {
 	font-family: Verdana;
-	font-size: 0.8em;
+	font-size: 1.1em;
+	margin: 0;
+	border-top: 0.8rem solid #455A64;
 }
+
+
+.topbar {
+	background-color: #607D8B;
+	color: #fff;
+	box-shadow: 0px 3px 5px 0px #b6b6b6;
+	padding: 1em;
+}
+
+
+.addevent {
+
+}
+
+
 .eventstream {
-	float: left;
+	font-size: 1.2em;
+	max-height: 15em;
+	overflow-y: scroll;
 }
 li {
 	text-decoration: none;
@@ -17,27 +36,26 @@ li.completed {
 
 
 .timeline {
-	float: left;
 	list-style-type: none;
-	width: 455px;
-	padding: 0;
+	padding: 1em;
 	margin: 0;
 }
 .timeline li {
-	min-height: 2em;
-	border-bottom: 1px dotted #ddd;
+	min-height: 2.3em;
+	border-bottom: 1px dotted #b6b6b6;
 }
 .timeline__time {
 	position: absolute;
-	width: 49px;
-	line-height: 2em;
-	height: 2em;
+	width: 3.5em;
+	line-height: 2.3em;
+	height: 2.3em;
+	font-size: 1em;
 }
 .timeline__events {
 	display: inline-block;
-	min-height: 2em;
-	border-left: 1px solid #bbb;
-	margin-left: 50px;
+	min-height: 2.3em;
+	border-left: 1px solid #b6b6b6;
+	margin-left: 3.5em;
 }
 .event {
 	display: inline-block;
@@ -50,11 +68,12 @@ li.completed {
 }
 
 .event__severity-info {
-	background-color: #A3BE8C;
-	border-color: darkgreen;
+	background-color: #DCEDC8;
+	color: #212121;
+	border-color: #689F38;
 }
 .event__severity-alert {
-	background-color: #BF616A;
+	background-color: #FF5722;
 	border-color: darkred;
 	color: white;
 }

--- a/styles/app.css
+++ b/styles/app.css
@@ -15,7 +15,7 @@ body {
 
 
 .addevent {
-
+	text-align: center;
 }
 
 
@@ -41,7 +41,8 @@ li.completed {
 	margin: 0;
 }
 .timeline li {
-	min-height: 2.3em;
+	min-height: 2.4em;
+	padding-bottom: 2px;
 	border-bottom: 1px dotted #b6b6b6;
 }
 .timeline__time {
@@ -50,21 +51,34 @@ li.completed {
 	line-height: 2.3em;
 	height: 2.3em;
 	font-size: 1em;
+	color: #b6b6b6;
 }
 .timeline__events {
-	display: inline-block;
-	min-height: 2.3em;
+	display: flex;
+	align-items: center;
+	justify-content: space-around;
+	min-height: 2.4em;
 	border-left: 1px solid #b6b6b6;
 	margin-left: 3.5em;
 }
 .event {
-	display: inline-block;
+	flex-grow: 1;
+	align-self: center;
+	margin-left: 0.5em;
 }
 .event__label {
 	padding: 3px 2px 4px;
 	margin-left: 2px;
 	border: 1px solid;
 	border-radius: 3px;
+}
+.event header {
+	width: 100%;
+	font-size: 0.8em;
+}
+.event time {
+	margin-right: 2px;
+	font-weight: bold;
 }
 
 .event__severity-info {
@@ -73,12 +87,13 @@ li.completed {
 	border-color: #689F38;
 }
 .event__severity-alert {
-	background-color: #FF5722;
+	flex-grow: 1.5;
+	background-color: #E64A19;
 	border-color: darkred;
 	color: white;
 }
 
 .event-completed {
-	opacity: 0.6;
+	opacity: 0.4;
 	text-decoration: line-through;
 }

--- a/styles/paginator.css
+++ b/styles/paginator.css
@@ -1,0 +1,25 @@
+.paginator {
+	display: flex;
+	align-items: center;
+}
+.paginator-button {
+	flex-grow: 1;
+	flex-basis: 25%;
+	padding: 3px;
+	margin: 3px;
+
+	background-color: #607D8B;
+	border: 1px solid #607D8B;
+	color: #CFD8DC;
+	text-align: center;
+	text-decoration: none;
+}
+.paginator-button:hover {
+	border: 1px solid #B6B6B6;
+}
+.paginator-currentdate {
+	flex-grow: 1;
+	flex-basis: 50%;
+	text-align: center;
+	font-size: 1.5em;
+}

--- a/styles/paginator.css
+++ b/styles/paginator.css
@@ -22,4 +22,5 @@
 	flex-basis: 50%;
 	text-align: center;
 	font-size: 1.5em;
+	font-weight: bolder;
 }


### PR DESCRIPTION
Sad attempts to make the dashboard look a bit more like a dashboard.

- full width timeline interface
- event list at the bottom of the page, no specific styles applied ATM
- use flexbox for rendering timeline events, no more width calculation at the JS level
- events show the timestamp in a header, alongside with a slack username if available
- nicer add custom event form, incredible effort: `text-align: center;` :-(
- strip the "changelog command" from slack messages (which was renamed BTW to `/changelog`)